### PR TITLE
 [Feature] Add a implemention of multi-GPU inference using ulysses sequence parallel 

### DIFF
--- a/radial_attn/attn_mask.py
+++ b/radial_attn/attn_mask.py
@@ -341,6 +341,9 @@ def RadialAttention(query, key, value, mask_map=None, sparsity_type="radial", bl
             num_qo_heads=num_head,
             num_kv_heads=num_head,
             head_dim=hidden_dim,
+            q_data_type=query.dtype,
+            kv_data_type=key.dtype,
+            o_data_type=query.dtype,
         )
         
         return FlashInferBackend(query, key, value, mask_map, pre_defined_mask, bsr_wrapper)

--- a/radial_attn/models/wan/attention.py
+++ b/radial_attn/models/wan/attention.py
@@ -11,7 +11,7 @@ from torch.nn.attention import sdpa_kernel, SDPBackend
 import torch.distributed as dist
 
 try:
-    from xfuser.core.distributed import get_ulysses_parallel_world_size,get_ulysses_parallel_rank,get_sp_group
+    from xfuser.core.distributed import get_ulysses_parallel_world_size
     from xfuser.model_executor.layers.usp import _ft_c_input_all_to_all, _ft_c_output_all_to_all
 except:
     pass

--- a/radial_attn/models/wan/attention.py
+++ b/radial_attn/models/wan/attention.py
@@ -8,6 +8,13 @@ from diffusers.models.transformers.transformer_wan import WanAttention, _get_qkv
 from einops import rearrange
 from ...attn_mask import RadialAttention
 from torch.nn.attention import sdpa_kernel, SDPBackend
+import torch.distributed as dist
+
+try:
+    from xfuser.core.distributed import get_ulysses_parallel_world_size,get_ulysses_parallel_rank,get_sp_group
+    from xfuser.model_executor.layers.usp import _ft_c_input_all_to_all, _ft_c_output_all_to_all
+except:
+    pass
 
 class WanSparseAttnProcessor:
     _attention_backend = None
@@ -24,6 +31,10 @@ class WanSparseAttnProcessor:
                 "WanAttnProcessor requires PyTorch 2.0. To use it, please upgrade PyTorch to version 2.0 or higher."
             )
         self.layer_idx = layer_idx
+        self.use_sp = False
+
+        if dist.is_initialized() and get_ulysses_parallel_world_size() > 1:
+            self.use_sp = True
 
     def __call__(
         self,
@@ -97,10 +108,25 @@ class WanSparseAttnProcessor:
                 
         else: # case for sparse attention
             batch_size = query.shape[0]
-            # transform (batch_size, num_heads, seq_len, head_dim) to (seq_len * batch_size, num_heads, head_dim)
-            query = rearrange(query, "b s h d -> (b s) h d")
-            key = rearrange(key, "b s h d -> (b s) h d")
-            value = rearrange(value, "b s h d -> (b s) h d")
+            if self.use_sp:
+                # Ugly but useful now. TODO: modify all_to_all fuc of xdit to handle different layouts
+                query = rearrange(query, "b s h d" " -> b h s d").contiguous()
+                key = rearrange(key, "b s h d" " -> b h s d").contiguous()
+                value = rearrange(value, "b s h d" " -> b h s d").contiguous()
+                
+                # input all_to_all comm needs [b h s d] layout
+                query = _ft_c_input_all_to_all(query)
+                key = _ft_c_input_all_to_all(key)
+                value = _ft_c_input_all_to_all(value)
+
+                query = rearrange(query, "b h s d -> (b s) h d").contiguous()
+                key = rearrange(key, "b h s d -> (b s) h d").contiguous()
+                value = rearrange(value, "b h s d -> (b s) h d").contiguous()
+            else:
+                query = rearrange(query, "b s h d -> (b s) h d")
+                key = rearrange(key, "b s h d -> (b s) h d")
+                value = rearrange(value, "b s h d -> (b s) h d")
+
             if numerical_timestep < self.dense_timestep or self.layer_idx < self.dense_block or self.sparse_type == "dense":
                 hidden_states = RadialAttention(
                     query=query, key=key, value=value, mask_map=self.mask_map, sparsity_type="dense", block_size=128, decay_factor=self.decay_factor, model_type="wan", pre_defined_mask=None, use_sage_attention=self.use_sage_attention
@@ -110,8 +136,14 @@ class WanSparseAttnProcessor:
                 hidden_states = RadialAttention(
                     query=query, key=key, value=value, mask_map=self.mask_map, sparsity_type="radial", block_size=128, decay_factor=self.decay_factor, model_type="wan", pre_defined_mask=None, use_sage_attention=self.use_sage_attention
                 )
-            # transform back to (batch_size, num_heads, seq_len, head_dim)
-            hidden_states = rearrange(hidden_states, "(b s) h d -> b s h d", b=batch_size)
+            
+            if self.use_sp:
+                hidden_states = rearrange(hidden_states.contiguous(), "(b s) h d -> b h s d", b=batch_size).contiguous()
+                # output all_to_all comm needs [b h s d] layout
+                hidden_states = _ft_c_output_all_to_all(hidden_states)
+                hidden_states = rearrange(hidden_states, "b h s d -> b s h d", b=batch_size).contiguous()
+            else:
+                hidden_states = rearrange(hidden_states, "(b s) h d -> b s h d", b=batch_size)
 
         # hidden_states = dispatch_attention_fn(
         #     query,

--- a/radial_attn/models/wan/sparse_transformer.py
+++ b/radial_attn/models/wan/sparse_transformer.py
@@ -12,6 +12,16 @@ logger = logging.get_logger(__name__)
 from typing import Any, Callable, Dict, List, Optional, Union
 from diffusers.callbacks import MultiPipelineCallbacks, PipelineCallback
 from diffusers.pipelines.wan.pipeline_output import WanPipelineOutput
+import torch.distributed as dist
+
+try:
+    from xfuser.core.distributed import (
+        get_ulysses_parallel_world_size,
+        get_ulysses_parallel_rank,
+        get_sp_group
+    )
+except:
+    pass
 
 class WanTransformerBlock_Sparse(WanTransformerBlock):
     def forward(
@@ -40,10 +50,21 @@ class WanTransformerBlock_Sparse(WanTransformerBlock):
                 self.scale_shift_table + temb.float()
             ).chunk(6, dim=1)
 
+        # if dist.is_initialized() and get_ulysses_parallel_world_size() > 1:
+        #     # split video latents on dim TS
+        #     hidden_states = torch.chunk(hidden_states, get_ulysses_parallel_world_size(), dim=-2)[get_ulysses_parallel_rank()]
+        #     rotary_emb = (
+        #         torch.chunk(rotary_emb[0], get_ulysses_parallel_world_size(), dim=1)[get_ulysses_parallel_rank()],
+        #         torch.chunk(rotary_emb[1], get_ulysses_parallel_world_size(), dim=1)[get_ulysses_parallel_rank()],
+        #     ) 
+
         # 1. Self-attention
         norm_hidden_states = (self.norm1(hidden_states.float()) * (1 + scale_msa) + shift_msa).type_as(hidden_states)
         attn_output = self.attn1(hidden_states=norm_hidden_states, rotary_emb=rotary_emb, numerical_timestep=numeral_timestep)
-        hidden_states = (hidden_states.float() + attn_output * gate_msa).type_as(hidden_states)
+        hidden_states = (hidden_states.float() + attn_output * gate_msa).type_as(hidden_states).contiguous()
+
+        # if dist.is_initialized() and get_ulysses_parallel_world_size() > 1:
+        #     hidden_states = get_sp_group().all_gather(hidden_states.contiguous(), dim=-2)
 
         # 2. Cross-attention
         norm_hidden_states = self.norm2(hidden_states.float()).type_as(hidden_states)
@@ -117,6 +138,14 @@ class WanTransformer3DModel_Sparse(WanTransformer3DModel):
         if encoder_hidden_states_image is not None:
             encoder_hidden_states = torch.concat([encoder_hidden_states_image, encoder_hidden_states], dim=1)
 
+        if dist.is_initialized() and get_ulysses_parallel_world_size() > 1:
+            # split video latents on dim TS
+            hidden_states = torch.chunk(hidden_states, get_ulysses_parallel_world_size(), dim=-2)[get_ulysses_parallel_rank()]
+            rotary_emb = (
+                torch.chunk(rotary_emb[0], get_ulysses_parallel_world_size(), dim=1)[get_ulysses_parallel_rank()],
+                torch.chunk(rotary_emb[1], get_ulysses_parallel_world_size(), dim=1)[get_ulysses_parallel_rank()],
+            )
+
         # 4. Transformer blocks
         if torch.is_grad_enabled() and self.gradient_checkpointing:
             for block in self.blocks:
@@ -152,6 +181,9 @@ class WanTransformer3DModel_Sparse(WanTransformer3DModel):
 
         hidden_states = (self.norm_out(hidden_states.float()) * (1 + scale) + shift).type_as(hidden_states)
         hidden_states = self.proj_out(hidden_states)
+
+        if dist.is_initialized() and get_ulysses_parallel_world_size() > 1:
+            hidden_states = get_sp_group().all_gather(hidden_states, dim=-2)
 
         hidden_states = hidden_states.reshape(
             batch_size, post_patch_num_frames, post_patch_height, post_patch_width, p_t, p_h, p_w, -1

--- a/radial_attn/models/wan2_2/attention.py
+++ b/radial_attn/models/wan2_2/attention.py
@@ -8,6 +8,13 @@ from diffusers.models.transformers.transformer_wan import WanAttention, _get_qkv
 from einops import rearrange
 from ...attn_mask import RadialAttention
 from torch.nn.attention import sdpa_kernel, SDPBackend
+import torch.distributed as dist
+
+try:
+    from xfuser.core.distributed import get_ulysses_parallel_world_size
+    from xfuser.model_executor.layers.usp import _ft_c_input_all_to_all, _ft_c_output_all_to_all
+except:
+    pass
 
 class Wan22SparseAttnProcessor:
     """
@@ -27,6 +34,10 @@ class Wan22SparseAttnProcessor:
                 "Wan22SparseAttnProcessor requires PyTorch 2.0. To use it, please upgrade PyTorch to version 2.0 or higher."
             )
         self.layer_idx = layer_idx
+        self.use_sp = False
+
+        if dist.is_initialized() and get_ulysses_parallel_world_size() > 1:
+            self.use_sp = True
 
     def __call__(
         self,
@@ -105,22 +116,65 @@ class Wan22SparseAttnProcessor:
                 timestep_value = numerical_timestep.item() if numerical_timestep.numel() == 1 else numerical_timestep[0].item()
             
             if timestep_value < self.dense_timestep or self.layer_idx < self.dense_block or self.sparse_type == "dense":
+                if self.use_sp:
+                    batch_size = query.shape[0]
+                    # Ugly but useful now. TODO: modify all_to_all fuc of xdit to handle different layouts
+                    query = rearrange(query, "b s h d" " -> b h s d").contiguous()
+                    key = rearrange(key, "b s h d" " -> b h s d").contiguous()
+                    value = rearrange(value, "b s h d" " -> b h s d").contiguous()
+                    
+                    # input all_to_all comm needs [b h s d] layout
+                    query = _ft_c_input_all_to_all(query)
+                    key = _ft_c_input_all_to_all(key)
+                    value = _ft_c_input_all_to_all(value)
+
+                    query = rearrange(query, "b h s d" " -> b s h d").contiguous()
+                    key = rearrange(key, "b h s d" " -> b s h d").contiguous()
+                    value = rearrange(value, "b h s d" " -> b s h d").contiguous()
+
                 hidden_states = dispatch_attention_fn(
                     query=query, key=key, value=value,
                     attn_mask=attention_mask, dropout_p=0.0, is_causal=False, backend=self._attention_backend,
                 )
+
+                if self.use_sp:
+                    hidden_states = rearrange(hidden_states.contiguous(), "b s h d -> b h s d", b=batch_size).contiguous()
+                    # output all_to_all comm needs [b h s d] layout
+                    hidden_states = _ft_c_output_all_to_all(hidden_states)
+                    hidden_states = rearrange(hidden_states, "b h s d -> b s h d", b=batch_size).contiguous()
             else:
                 batch_size = query.shape[0]
-                # transform (batch_size, num_heads, seq_len, head_dim) to (seq_len * batch_size, num_heads, head_dim)
-                query = rearrange(query, "b s h d -> (b s) h d")
-                key = rearrange(key, "b s h d -> (b s) h d")
-                value = rearrange(value, "b s h d -> (b s) h d")
+                if self.use_sp:
+                    # Ugly but useful now. TODO: modify all_to_all fuc of xdit to handle different layouts
+                    query = rearrange(query, "b s h d" " -> b h s d").contiguous()
+                    key = rearrange(key, "b s h d" " -> b h s d").contiguous()
+                    value = rearrange(value, "b s h d" " -> b h s d").contiguous()
+                    
+                    # input all_to_all comm needs [b h s d] layout
+                    query = _ft_c_input_all_to_all(query)
+                    key = _ft_c_input_all_to_all(key)
+                    value = _ft_c_input_all_to_all(value)
+
+                    query = rearrange(query, "b h s d -> (b s) h d").contiguous()
+                    key = rearrange(key, "b h s d -> (b s) h d").contiguous()
+                    value = rearrange(value, "b h s d -> (b s) h d").contiguous()
+                else:
+                    query = rearrange(query, "b s h d -> (b s) h d")
+                    key = rearrange(key, "b s h d -> (b s) h d")
+                    value = rearrange(value, "b s h d -> (b s) h d")
+                
                 # apply radial attention
                 hidden_states = RadialAttention(
                     query=query, key=key, value=value, mask_map=self.mask_map, sparsity_type="radial", block_size=64, decay_factor=self.decay_factor, model_type="wan", pre_defined_mask=None, use_sage_attention=self.use_sage_attention
                 )
-                # transform back to (batch_size, num_heads, seq_len, head_dim)
-                hidden_states = rearrange(hidden_states, "(b s) h d -> b s h d", b=batch_size)
+
+                if self.use_sp:
+                    hidden_states = rearrange(hidden_states.contiguous(), "(b s) h d -> b h s d", b=batch_size).contiguous()
+                    # output all_to_all comm needs [b h s d] layout
+                    hidden_states = _ft_c_output_all_to_all(hidden_states)
+                    hidden_states = rearrange(hidden_states, "b h s d -> b s h d", b=batch_size).contiguous()
+                else:
+                    hidden_states = rearrange(hidden_states, "(b s) h d -> b s h d", b=batch_size)
 
         hidden_states = hidden_states.flatten(2, 3)
         hidden_states = hidden_states.type_as(query)
@@ -147,7 +201,10 @@ class Wan22SparseAttnProcessor2_0:
     def __init__(self, layer_idx):
         if not hasattr(F, "scaled_dot_product_attention"):
             raise ImportError("Wan22SparseAttnProcessor2_0 requires PyTorch 2.0. To use it, please upgrade PyTorch to 2.0.")
-        self.layer_idx = layer_idx
+        self.use_sp = False
+
+        if dist.is_initialized() and get_ulysses_parallel_world_size() > 1:
+            self.use_sp = True
         
     def __call__(
         self,
@@ -223,10 +280,25 @@ class Wan22SparseAttnProcessor2_0:
                 )
         else: # this is the case for sparse attention
             batch_size = query.shape[0]
-            # transform (batch_size, num_heads, seq_len, head_dim) to (seq_len * batch_size, num_heads, head_dim)
-            query = rearrange(query, "b h s d -> (b s) h d")
-            key = rearrange(key, "b h s d -> (b s) h d")
-            value = rearrange(value, "b h s d -> (b s) h d")
+            if self.use_sp:
+                batch_size = query.shape[0]
+                # Ugly but useful now. TODO: modify all_to_all fuc of xdit to handle different layouts
+                query = rearrange(query, "b s h d" " -> b h s d").contiguous()
+                key = rearrange(key, "b s h d" " -> b h s d").contiguous()
+                value = rearrange(value, "b s h d" " -> b h s d").contiguous()
+                
+                # input all_to_all comm needs [b h s d] layout
+                query = _ft_c_input_all_to_all(query)
+                key = _ft_c_input_all_to_all(key)
+                value = _ft_c_input_all_to_all(value)
+
+                query = rearrange(query, "b h s d -> (b s) h d").contiguous()
+                key = rearrange(key, "b h s d -> (b s) h d").contiguous()
+                value = rearrange(value, "b h s d -> (b s) h d").contiguous()
+            else:
+                query = rearrange(query, "b s h d -> (b s) h d")
+                key = rearrange(key, "b s h d -> (b s) h d")
+                value = rearrange(value, "b s h d -> (b s) h d")
             
             # Handle both scalar and tensor numerical_timestep for wan2.2 compatibility
             timestep_value = numeral_timestep
@@ -242,9 +314,15 @@ class Wan22SparseAttnProcessor2_0:
                 hidden_states = RadialAttention(
                     query=query, key=key, value=value, mask_map=self.mask_map, sparsity_type="radial", block_size=128, decay_factor=self.decay_factor, model_type="wan", pre_defined_mask=None, use_sage_attention=self.use_sage_attention
                 )
-            # transform back to (batch_size, num_heads, seq_len, head_dim)
-            hidden_states = rearrange(hidden_states, "(b s) h d -> b h s d", b=batch_size)
-            
+                
+            if self.use_sp:
+                hidden_states = rearrange(hidden_states.contiguous(), "(b s) h d -> b h s d", b=batch_size).contiguous()
+                # output all_to_all comm needs [b h s d] layout
+                hidden_states = _ft_c_output_all_to_all(hidden_states)
+                hidden_states = rearrange(hidden_states, "b h s d -> b s h d", b=batch_size).contiguous()
+            else:
+                hidden_states = rearrange(hidden_states, "(b s) h d -> b s h d", b=batch_size)
+           
         hidden_states = hidden_states.transpose(1, 2).flatten(2, 3)
         hidden_states = hidden_states.type_as(query)
 

--- a/radial_attn/models/wan2_2/sparse_transformer.py
+++ b/radial_attn/models/wan2_2/sparse_transformer.py
@@ -10,6 +10,16 @@ logger = logging.get_logger(__name__)
 from typing import Any, Callable, Dict, List, Optional, Union
 from diffusers.callbacks import MultiPipelineCallbacks, PipelineCallback
 from diffusers.pipelines.wan.pipeline_output import WanPipelineOutput
+import torch.distributed as dist
+
+try:
+    from xfuser.core.distributed import (
+        get_ulysses_parallel_world_size,
+        get_ulysses_parallel_rank,
+        get_sp_group
+    )
+except:
+    pass
 
 class Wan22TransformerBlock_Sparse(WanTransformerBlock):
     """
@@ -123,6 +133,14 @@ class Wan22Transformer3DModel_Sparse(WanTransformer3DModel):
         if encoder_hidden_states_image is not None:
             encoder_hidden_states = torch.concat([encoder_hidden_states_image, encoder_hidden_states], dim=1)
 
+        if dist.is_initialized() and get_ulysses_parallel_world_size() > 1:
+            # split video latents on dim TS
+            hidden_states = torch.chunk(hidden_states, get_ulysses_parallel_world_size(), dim=-2)[get_ulysses_parallel_rank()]
+            rotary_emb = (
+                torch.chunk(rotary_emb[0], get_ulysses_parallel_world_size(), dim=1)[get_ulysses_parallel_rank()],
+                torch.chunk(rotary_emb[1], get_ulysses_parallel_world_size(), dim=1)[get_ulysses_parallel_rank()],
+            )
+
         # 4. Transformer blocks
         if torch.is_grad_enabled() and self.gradient_checkpointing:
             for block in self.blocks:
@@ -158,6 +176,10 @@ class Wan22Transformer3DModel_Sparse(WanTransformer3DModel):
 
         hidden_states = (self.norm_out(hidden_states.float()) * (1 + scale) + shift).type_as(hidden_states)
         hidden_states = self.proj_out(hidden_states)
+
+        if dist.is_initialized() and get_ulysses_parallel_world_size() > 1:
+            hidden_states = get_sp_group().all_gather(hidden_states, dim=-2)
+
 
         hidden_states = hidden_states.reshape(
             batch_size, post_patch_num_frames, post_patch_height, post_patch_width, p_t, p_h, p_w, -1

--- a/scripts/dist_hunyuan_t2v_inference.sh
+++ b/scripts/dist_hunyuan_t2v_inference.sh
@@ -1,0 +1,19 @@
+dense_layers=0
+dense_timesteps=10
+
+prompt=$(cat examples/prompt.txt)
+
+CUDA_VISIBLE_DEVICES=5,3,6,7 torchrun --nproc_per_node=4 \
+  hunyuan_t2v_inference.py \
+    --prompt "$prompt" \
+    --height 768 \
+    --width 1280 \
+    --num_frames 117 \
+    --dense_layers $dense_layers \
+    --dense_timesteps $dense_timesteps \
+    --decay_factor 0.95 \
+    --use_sequence_parallel \
+    --ulysses_degree 4 \
+    --num_inference_steps 50 \
+    --pattern "radial" \
+    --output_file "hunyuan_radial_sp4.mp4"

--- a/scripts/dist_wan_22_t2v_inference.sh
+++ b/scripts/dist_wan_22_t2v_inference.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Wan2.2 T2V inference script with radial attention
+# Default configuration for high-quality video generation
+
+dense_layers=1
+dense_timesteps=11
+decay_factor=0.8
+
+prompt="Two anthropomorphic cats in comfy boxing gear and bright gloves fight intensely on a spotlighted stage."
+
+# CUDA_VISIBLE_DEVICES=5,3,6,7 
+torchrun --nproc_per_node=4 \
+    wan_22_t2v_inference.py \
+    --prompt "$prompt" \
+    --height 768 \
+    --width 1280 \
+    --num_frames 77 \
+    --dense_layers $dense_layers \
+    --dense_timesteps $dense_timesteps \
+    --decay_factor $decay_factor \
+    --use_sequence_parallel \
+    --ulysses_degree 4 \
+    --pattern "radial" \
+    --guidance_scale 4.0 \
+    --guidance_scale_2 3.0 \
+    --num_inference_steps 40 \
+    --output_file "wan22_radial_output_sp4.mp4" 

--- a/scripts/dist_wan_t2v_inference.sh
+++ b/scripts/dist_wan_t2v_inference.sh
@@ -1,0 +1,20 @@
+# this is the setting for 1x length T2V inference
+dense_layers=1
+dense_timesteps=10
+
+prompt=$(cat examples/prompt.txt)
+
+CUDA_VISIBLE_DEVICES=5,3,6,7 torchrun --nproc_per_node=4 \
+    wan_t2v_inference.py \
+    --prompt "$prompt" \
+    --height 768 \
+    --width 1280 \
+    --num_frames 69 \
+    --dense_layers $dense_layers \
+    --dense_timesteps $dense_timesteps \
+    --decay_factor 0.2 \
+    --use_sequence_parallel \
+    --ulysses_degree 4 \
+    --num_inference_steps 50 \
+    --pattern "radial" \
+    --output_file "wan_radial_sp4.mp4"

--- a/wan_22_t2v_inference.py
+++ b/wan_22_t2v_inference.py
@@ -36,9 +36,46 @@ if __name__ == "__main__":
     parser.add_argument("--decay_factor", type=float, default=1, help="Decay factor for the Wan attention, we use this to control window width")
     parser.add_argument("--use_sage_attention", action="store_true", help="Use SAGE attention for quantized inference")
     parser.add_argument("--use_model_offload", action="store_true", help="Enable model offloading to CPU for memory efficiency")
+    parser.add_argument("--use_sequence_parallel", action="store_true",default=False, help="Enable sequence parallelism for parallel inference")
+    parser.add_argument("--ulysses_degree", type=int, default=1, help="The number of ulysses parallel")
+    
     args = parser.parse_args()
     
     set_seed(args.seed)
+    
+    if args.use_sequence_parallel:
+        import torch.distributed as dist
+        rank = int(os.getenv("RANK", 0))
+        world_size = int(os.getenv("WORLD_SIZE", 1))
+        local_rank = int(os.getenv("LOCAL_RANK", 0))
+        device = local_rank
+
+        if world_size > 1:
+            torch.cuda.set_device(local_rank)
+            dist.init_process_group(
+                backend="nccl",
+                init_method="env://",
+                rank=rank,
+                world_size=world_size)
+
+            if args.ulysses_degree > 1 and world_size == args.ulysses_degree:
+                from xfuser.core.distributed import (
+                    init_distributed_environment,
+                    initialize_model_parallel,
+                )
+
+                init_distributed_environment(
+                    rank=dist.get_rank(), world_size=dist.get_world_size())
+
+                initialize_model_parallel(
+                    sequence_parallel_degree=dist.get_world_size(),
+                    ring_degree=1,
+                    ulysses_degree=args.ulysses_degree,
+                )
+            else:
+                assert "only ulysses parallelism is supported now"
+        else:
+            assert "parallel world_size must bigger than 1"
     
     replace_wan22_sparse_forward()
     

--- a/wan_t2v_inference.py
+++ b/wan_t2v_inference.py
@@ -36,14 +36,52 @@ if __name__ == "__main__":
     parser.add_argument("--decay_factor", type=float, default=1, help="Decay factor for the Wan attention, we use this to control window width")
     parser.add_argument("--use_sage_attention", action="store_true", help="Use SAGE attention for quantized inference")
     parser.add_argument("--use_model_offload", action="store_true", help="Enable model offloading to CPU for memory efficiency")
+    # Parallel inference parameters
+    parser.add_argument("--use_sequence_parallel", action="store_true",default=False, help="Enable sequence parallelism for parallel inference")
+    parser.add_argument("--ulysses_degree", type=int, default=1, help="The number of ulysses parallel")
+    
     args = parser.parse_args()
     
     set_seed(args.seed)
+
+    if args.use_sequence_parallel:
+        import torch.distributed as dist
+        rank = int(os.getenv("RANK", 0))
+        world_size = int(os.getenv("WORLD_SIZE", 1))
+        local_rank = int(os.getenv("LOCAL_RANK", 0))
+        device = local_rank
+
+        if world_size > 1:
+            torch.cuda.set_device(local_rank)
+            dist.init_process_group(
+                backend="nccl",
+                init_method="env://",
+                rank=rank,
+                world_size=world_size)
+
+            if args.ulysses_degree > 1 and world_size == args.ulysses_degree:
+                from xfuser.core.distributed import (
+                    init_distributed_environment,
+                    initialize_model_parallel,
+                )
+
+                init_distributed_environment(
+                    rank=dist.get_rank(), world_size=dist.get_world_size())
+
+                initialize_model_parallel(
+                    sequence_parallel_degree=dist.get_world_size(),
+                    ring_degree=1,
+                    ulysses_degree=args.ulysses_degree,
+                )
+            else:
+                assert "only ulysses parallelism is supported now"
+        else:
+            assert "parallel world_size must bigger than 1"
     
     replace_sparse_forward()
     
     # Available models: Wan-AI/Wan2.1-T2V-14B-Diffusers, Wan-AI/Wan2.1-T2V-1.3B-Diffusers
-    model_id = "Wan-AI/Wan2.1-T2V-14B-Diffusers"
+    model_id = args.model_id
     vae = AutoencoderKLWan.from_pretrained(model_id, subfolder="vae", torch_dtype=torch.float32)
     flow_shift = args.flow_shift
     text_encoder = UMT5EncoderModel.from_pretrained(model_id, subfolder="text_encoder", torch_dtype=torch.bfloat16)


### PR DESCRIPTION
- tested on A100/H100 + torch2.6 + flashinfer0.2.8 + xfuser0.4.1(from [xDiT](https://github.com/xdit-project/xDiT/tree/main) project)
- the inference speed can speed up 3.8x (4 GPU) / 7.4x (8 GPU)
- Dense parallel results are completely consistent with single-GPU execution, while sparse(radial) parallel results show slight differences from single-GPU execution (PSNR differences are within 0.5 across different test cases, with mixed results). I suspect this discrepancy may be due to different sparse kernels being selected by flashinfer based on different num_heads.
- Currently, sequence parallelism, radial sparsity, and sageattention are not yet supported.
- Usage: scripts/dist_wan_t2v_inference.sh/ scripts/dist_wan_22_t2v_inference.sh / scripts/dist_hunyuan_t2v_inference.sh / 


### **Visualization**
wan_dense_single_infer:

https://github.com/user-attachments/assets/f462b468-bc0b-4675-ac73-9d75cb74909e


wan_dense_sp4:

https://github.com/user-attachments/assets/05715a71-d8de-401b-8181-4d7aa10d53d0


wan_radial_singe_infer:

https://github.com/user-attachments/assets/e9f01053-94d2-4208-a68e-d53a959fd3e8

wan_radial_sp2:

https://github.com/user-attachments/assets/09ffb043-23b7-4542-9243-2f593270ccbc


wan_radial_sp4:


https://github.com/user-attachments/assets/4b89719d-641a-460b-b92f-3d23dbf8f142

